### PR TITLE
Makes All Sec Guards know krav maga at roundstart

### DIFF
--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -59,7 +59,7 @@ Head of Security
 	duffelbag = /obj/item/storage/backpack/duffelbag/sec
 	box = /obj/item/storage/box/security
 
-	implants = list(/obj/item/implant/mindshield)
+	implants = list(/obj/item/implant/mindshield, /obj/item/implant/krav_maga)
 
 /*
 Warden
@@ -295,7 +295,7 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 	duffelbag = /obj/item/storage/backpack/duffelbag/sec
 	box = /obj/item/storage/box/security
 
-	implants = list(/obj/item/implant/mindshield)
+	implants = list(/obj/item/implant/mindshield, /obj/item/implant/krav_maga)
 
 
 /obj/item/device/radio/headset/headset_sec/alt/department/Initialize()


### PR DESCRIPTION
apologies if this is wrong, i am new and retarded.

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: optional name here
add: Added new things

/:cl:

[why]: # Got approved on forums, gist was sec guards are too easy to shit on, and should know krav maga as they are trained officers. Full explanation here: 
https://hippiestation.com/threads/have-all-sec-guards-know-krav-maga.8253/